### PR TITLE
add powerDist logging variables to detect motor saturation

### DIFF
--- a/src/modules/src/planner.c
+++ b/src/modules/src/planner.c
@@ -48,7 +48,7 @@ static void plan_takeoff_or_landing(struct planner *p, struct vec curr_pos, floa
 	// compute the shortest possible rotation towards 0
 	hover_yaw = normalize_radians(hover_yaw);
 	curr_yaw = normalize_radians(curr_yaw);
-	float goal_yaw = hover_yaw + shortest_signed_angle_radians(curr_yaw, hover_yaw);
+	float goal_yaw = curr_yaw + shortest_signed_angle_radians(curr_yaw, hover_yaw);
 
 	piecewise_plan_7th_order_no_jerk(&p->planned_trajectory, duration,
 		curr_pos,  curr_yaw,  vzero(), 0, vzero(),
@@ -186,7 +186,7 @@ int plan_go_to_from(struct planner *p, const struct traj_eval *curr_eval, bool r
 	// compute the shortest possible rotation towards 0
 	float curr_yaw = normalize_radians(curr_eval->yaw);
 	hover_yaw = normalize_radians(hover_yaw);
-	float goal_yaw = hover_yaw + shortest_signed_angle_radians(curr_yaw, hover_yaw);
+	float goal_yaw = curr_yaw + shortest_signed_angle_radians(curr_yaw, hover_yaw);
 
 	piecewise_plan_7th_order_no_jerk(&p->planned_trajectory, duration,
 		curr_eval->pos, curr_yaw, curr_eval->vel, curr_eval->omega.z, curr_eval->acc,


### PR DESCRIPTION
I suggest computing the actual desired motor forces in the plotting code using these new logging variables. This way, you can have a stacked bar chart that also tells you roughly where the saturation is coming from.

This is int16 (2 bytes) to use less memory on the uSD card. The downside is that you'll need to convert it to grams before you plot.