### PR TITLE
add framework for lee_payload controller

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     },
     "files.associations": {
         "bootloader.h": "c"
-    }
+    },
+    "C_Cpp.errorSquiggles": "Disabled"
 }

--- a/bindings/cffirmware.i
+++ b/bindings/cffirmware.i
@@ -61,6 +61,7 @@
 #include "power_distribution.h"
 #include "controller_sjc.h"
 #include "controller_lee.h"
+#include "controller_lee_payload.h"
 %}
 
 %include "math3d.h"
@@ -74,6 +75,7 @@
 %include "power_distribution.h"
 %include "controller_sjc.h"
 %include "controller_lee.h"
+%include "controller_lee_payload.h"
 
 %inline %{
 struct poly4d* piecewise_get(struct piecewise_traj *pp, int i)

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -29,6 +29,7 @@ fw_sources = [
     "src/modules/src/power_distribution_quadrotor.c",
     "src/modules/src/controller_sjc.c",
     "src/modules/src/controller_lee.c",
+    "src/modules/src/controller_lee_payload.c",
 ]
 
 cffirmware = Extension(

--- a/src/modules/interface/controller_lee_payload.h
+++ b/src/modules/interface/controller_lee_payload.h
@@ -21,32 +21,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * controller.h - Controller interface
  */
-#ifndef __CONTROLLER_H__
-#define __CONTROLLER_H__
+#ifndef __CONTROLLER_LEE_PAYLOAD_H__
+#define __CONTROLLER_LEE_PAYLOAD_H__
 
 #include "stabilizer_types.h"
 
-typedef enum {
-  ControllerTypeAny,
-  ControllerTypePID,
-  ControllerTypeMellinger,
-  ControllerTypeINDI,
-  ControllerTypeSJC,
-  ControllerTypeMellingerSI,
-  ControllerTypeLee,
-  ControllerTypeLeePayload,
-  ControllerType_COUNT,
-} ControllerType;
-
-void controllerInit(ControllerType controller);
-bool controllerTest(void);
-void controller(control_t *control, setpoint_t *setpoint,
+void controllerLeePayloadInit(void);
+bool controllerLeePayloadTest(void);
+void controllerLeePayload(control_t *control, setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick);
-ControllerType getControllerType(void);
-const char* controllerGetName();
 
-#endif //__CONTROLLER_H__
+#endif //__CONTROLLER_LEE_PAYLOAD_H__

--- a/src/modules/interface/math3d.h
+++ b/src/modules/interface/math3d.h
@@ -382,6 +382,24 @@ static inline struct mat33 mcolumns(struct vec a, struct vec b, struct vec c) {
 
 	return m;
 }
+// construct a matrix from two vectors A = q*q.T 
+static inline struct mat33 vecmult(struct vec a) {
+	struct mat33 m;
+	m.m[0][0] = a.x*a.x;
+	m.m[1][0] = a.y*a.x;
+	m.m[2][0] = a.z*a.x;
+
+	m.m[0][1] = a.x*a.y;
+	m.m[1][1] = a.y*a.y;
+	m.m[2][1] = a.z*a.y;
+
+	m.m[0][2] = a.x*a.x;
+	m.m[1][2] = a.y*a.z;
+	m.m[2][2] = a.z*a.z;
+
+	return m;
+}
+
 // construct a matrix from three row vectors.
 static inline struct mat33 mrows(struct vec a, struct vec b, struct vec c) {
 	struct mat33 m;

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -190,6 +190,7 @@ typedef struct control_s {
     struct {
       float thrustSI;  // N
       float torque[3]; // Nm
+      float u_all[3];
     };
     float normalizedForces[4]; // 0 ... 1
   };

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -166,6 +166,10 @@ typedef struct state_s {
   point_t position;         // m
   velocity_t velocity;      // m/s
   acc_t acc;                // Gs (but acc.z without considering gravity)
+
+  // Measured state of the payload
+  point_t payload_pos;         // m   (world frame)
+  velocity_t payload_vel;      // m/s (world frame)
 } state_t;
 
 typedef enum control_mode_e {

--- a/src/modules/src/Kbuild
+++ b/src/modules/src/Kbuild
@@ -9,6 +9,7 @@ obj-y += comm.o
 obj-y += console.o
 obj-y += controller_indi.o
 obj-y += controller_lee.o
+obj-y += controller_lee_payload.o
 obj-y += controller_mellinger.o
 obj-y += controller_mellingerSI.o
 obj-y += controller.o

--- a/src/modules/src/controller.c
+++ b/src/modules/src/controller.c
@@ -9,6 +9,7 @@
 #include "controller_sjc.h"
 #include "controller_mellingerSI.h"
 #include "controller_lee.h"
+#include "controller_lee_payload.h"
 
 #include "autoconf.h"
 
@@ -32,6 +33,7 @@ static ControllerFcns controllerFunctions[] = {
   {.init = controllerSJCInit, .test = controllerSJCTest, .update = controllerSJC, .name = "SJC"},
   {.init = controllerMellingerSIInit, .test = controllerMellingerSITest, .update = controllerMellingerSI, .name = "MellingerSI"},
   {.init = controllerLeeInit, .test = controllerLeeTest, .update = controllerLee, .name = "Lee"},
+  {.init = controllerLeePayloadInit, .test = controllerLeePayloadTest, .update = controllerLeePayload, .name = "LeePayload"},
 };
 
 

--- a/src/modules/src/controller_lee.c
+++ b/src/modules/src/controller_lee.c
@@ -241,7 +241,7 @@ void controllerLee(control_t *control, setpoint_t *setpoint,
     hw = vscl(g_vehicleMass/control->thrustSI, tmp);
   }
   struct vec z_w = mkvec(0,0,1);
-  desiredYaw = setpoint->attitudeRate.yaw * vdot(mcolumn(R, 2),z_w);
+  desiredYaw = setpoint->attitudeRate.yaw * vdot(zdes,z_w);
   struct vec omega_des = mkvec(-vdot(hw,ydes), vdot(hw,xdes), desiredYaw);
   
   omega_r = mvmul(mmul(mtranspose(R), R_des), omega_des);

--- a/src/modules/src/controller_lee.c
+++ b/src/modules/src/controller_lee.c
@@ -240,9 +240,9 @@ void controllerLee(control_t *control, setpoint_t *setpoint,
     struct vec tmp = vsub(desJerk, vscl(vdot(zdes, desJerk), zdes));
     hw = vscl(g_vehicleMass/control->thrustSI, tmp);
   }
-  struct vec z_w = mkvec(0,0,1);
-  desiredYaw = setpoint->attitudeRate.yaw * vdot(zdes,z_w);
-  struct vec omega_des = mkvec(-vdot(hw,ydes), vdot(hw,xdes), desiredYaw);
+  struct vec z_w = mkvec(0,0,1); 
+  float desiredYawRate = radians(setpoint->attitudeRate.yaw) * vdot(zdes,z_w);
+  struct vec omega_des = mkvec(-vdot(hw,ydes), vdot(hw,xdes), desiredYawRate);
   
   omega_r = mvmul(mmul(mtranspose(R), R_des), omega_des);
 

--- a/src/modules/src/controller_lee.c
+++ b/src/modules/src/controller_lee.c
@@ -240,8 +240,9 @@ void controllerLee(control_t *control, setpoint_t *setpoint,
     struct vec tmp = vsub(desJerk, vscl(vdot(zdes, desJerk), zdes));
     hw = vscl(g_vehicleMass/control->thrustSI, tmp);
   }
-
-  struct vec omega_des = mkvec(-vdot(hw,ydes), vdot(hw,xdes), 0);
+  struct vec z_w = mkvec(0,0,1);
+  desiredYaw = setpoint->attitudeRate.yaw * vdot(mcolumn(R, 2),z_w);
+  struct vec omega_des = mkvec(-vdot(hw,ydes), vdot(hw,xdes), desiredYaw);
   
   omega_r = mvmul(mmul(mtranspose(R), R_des), omega_des);
 

--- a/src/modules/src/controller_lee.c
+++ b/src/modules/src/controller_lee.c
@@ -56,19 +56,19 @@ static float thrustSI;
 static struct vec J = {16.571710e-6, 16.655602e-6, 29.261652e-6}; // kg m^2
 
 // Position PID
-static struct vec Kpos_P = {20, 20, 20}; // Kp in paper
+static struct vec Kpos_P = {9, 9, 9}; // Kp in paper
 static float Kpos_P_limit = 100;
-static struct vec Kpos_D = {18, 18,18}; // Kv in paper
+static struct vec Kpos_D = {7, 7, 7}; // Kv in paper
 static float Kpos_D_limit = 100;
-static struct vec Kpos_I = {8, 8, 8}; // not in paper
+static struct vec Kpos_I = {5, 5, 5}; // not in paper
 static float Kpos_I_limit = 2;
 static struct vec i_error_pos;
 static struct vec p_error;
 static struct vec v_error;
 // Attitude PID
-static struct vec KR = {0.0055, 0.0055, 0.0055};
-static struct vec Komega = {0.0013, 0.0013, 0.0016};
-static struct vec KI = {0.005, 0.005, 0.005};
+static struct vec KR = {0.0055, 0.0055, 0.01};
+static struct vec Komega = {0.0013, 0.0013, 0.002};
+static struct vec KI = {0.012, 0.018, 0.015};
 static struct vec i_error_att;
 // Logging variables
 static struct vec rpy;

--- a/src/modules/src/controller_lee_payload.c
+++ b/src/modules/src/controller_lee_payload.c
@@ -1,0 +1,348 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2022 Khaled Wahba 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+This controller is based on the following publication:
+
+TODO
+*/
+
+#include <math.h>
+
+#include "param.h"
+#include "log.h"
+#include "math3d.h"
+#include "controller_lee_payload.h"
+
+#define GRAVITY_MAGNITUDE (9.81f)
+
+static float g_vehicleMass = 0.034; // TODO: should be CF global for other modules
+static float thrustSI;
+// Inertia matrix (diagonal matrix), see
+// System Identification of the Crazyflie 2.0 Nano Quadrocopter
+// BA theses, Julian Foerster, ETHZ
+// https://polybox.ethz.ch/index.php/s/20dde63ee00ffe7085964393a55a91c7
+static struct vec J = {16.571710e-6, 16.655602e-6, 29.261652e-6}; // kg m^2
+
+// Position PID
+static struct vec Kpos_P = {20, 20, 20}; // Kp in paper
+static float Kpos_P_limit = 100;
+static struct vec Kpos_D = {18, 18,18}; // Kv in paper
+static float Kpos_D_limit = 100;
+static struct vec Kpos_I = {0, 0, 0}; // not in paper
+static float Kpos_I_limit = 2;
+static struct vec i_error_pos;
+static struct vec p_error;
+static struct vec v_error;
+// Attitude PID
+static struct vec KR = {0.0055, 0.0055, 0.0055};
+static struct vec Komega = {0.0013, 0.0013, 0.0016};
+
+// Logging variables
+static struct vec rpy;
+static struct vec rpy_des;
+static struct vec qr;
+static struct mat33 R_des;
+static struct vec omega;
+static struct vec omega_r;
+static struct vec u;
+
+// static uint32_t ticks;
+
+static inline struct vec vclampscl(struct vec value, float min, float max) {
+  return mkvec(
+    clamp(value.x, min, max),
+    clamp(value.y, min, max),
+    clamp(value.z, min, max));
+}
+
+void controllerLeePayloadReset(void)
+{
+  i_error_pos = vzero();
+}
+
+void controllerLeePayloadInit(void)
+{
+  controllerLeePayloadReset();
+}
+
+bool controllerLeePayloadTest(void)
+{
+  return true;
+}
+
+void controllerLeePayload(control_t *control, setpoint_t *setpoint,
+                                         const sensorData_t *sensors,
+                                         const state_t *state,
+                                         const uint32_t tick)
+{
+
+
+  if (!RATE_DO_EXECUTE(ATTITUDE_RATE, tick)) {
+    return;
+  }
+
+  // uint64_t startTime = usecTimestamp();
+
+  float dt = (float)(1.0f/ATTITUDE_RATE);
+  // struct vec dessnap = vzero();
+  // Address inconsistency in firmware where we need to compute our own desired yaw angle
+  // Rate-controlled YAW is moving YAW angle setpoint
+  float desiredYaw = 0; //rad
+  if (setpoint->mode.yaw == modeVelocity) {
+    desiredYaw = radians(state->attitude.yaw + setpoint->attitudeRate.yaw * dt);
+  } else if (setpoint->mode.yaw == modeAbs) {
+    desiredYaw = radians(setpoint->attitude.yaw);
+  } else if (setpoint->mode.quat == modeAbs) {
+    struct quat setpoint_quat = mkquat(setpoint->attitudeQuaternion.x, setpoint->attitudeQuaternion.y, setpoint->attitudeQuaternion.z, setpoint->attitudeQuaternion.w);
+    rpy_des = quat2rpy(setpoint_quat);
+    desiredYaw = rpy_des.z;
+  }
+
+  // Position controller
+  if (   setpoint->mode.x == modeAbs
+      || setpoint->mode.y == modeAbs
+      || setpoint->mode.z == modeAbs) {
+    struct vec pos_d = mkvec(setpoint->position.x, setpoint->position.y, setpoint->position.z);
+    struct vec vel_d = mkvec(setpoint->velocity.x, setpoint->velocity.y, setpoint->velocity.z);
+    struct vec acc_d = mkvec(setpoint->acceleration.x, setpoint->acceleration.y, setpoint->acceleration.z + GRAVITY_MAGNITUDE);
+    struct vec statePos = mkvec(state->position.x, state->position.y, state->position.z);
+    struct vec stateVel = mkvec(state->velocity.x, state->velocity.y, state->velocity.z);
+
+    // errors
+    struct vec pos_e = vclampscl(vsub(pos_d, statePos), -Kpos_P_limit, Kpos_P_limit);
+    struct vec vel_e = vclampscl(vsub(vel_d, stateVel), -Kpos_D_limit, Kpos_D_limit);
+
+    p_error = pos_e;
+    v_error = vel_e;
+
+    struct vec F_d = vadd3(
+      acc_d,
+      veltmul(Kpos_D, vel_e),
+      veltmul(Kpos_P, pos_e));
+    
+   
+    struct quat q = mkquat(state->attitudeQuaternion.x, state->attitudeQuaternion.y, state->attitudeQuaternion.z, state->attitudeQuaternion.w);
+    struct mat33 R = quat2rotmat(q);
+    struct vec z  = vbasis(2);
+    control->thrustSI = g_vehicleMass*vdot(F_d , mvmul(R, z));
+    thrustSI = control->thrustSI;
+    // Reset the accumulated error while on the ground
+    if (control->thrustSI < 0.01f) {
+      controllerLeePayloadReset();
+    }
+
+  // Compute Desired Rotation matrix
+    float normFd = control->thrustSI;
+
+    struct vec xdes = vbasis(0);
+    struct vec ydes = vbasis(1);
+    struct vec zdes = vbasis(2);
+   
+    if (normFd > 0) {
+      zdes = vnormalize(F_d);
+    } 
+    struct vec xcdes = mkvec(cosf(desiredYaw), sinf(desiredYaw), 0); 
+    struct vec zcrossx = vcross(zdes, xcdes);
+    float normZX = vmag(zcrossx);
+
+    if (normZX > 0) {
+      ydes = vnormalize(zcrossx);
+    } 
+    xdes = vcross(ydes, zdes);
+    
+    R_des = mcolumns(xdes, ydes, zdes);
+
+  } else {
+    if (setpoint->mode.z == modeDisable) {
+      if (setpoint->thrust < 1000) {
+          control->controlMode = controlModeForceTorque;
+          control->thrustSI  = 0;
+          control->torque[0] = 0;
+          control->torque[1] = 0;
+          control->torque[2] = 0;
+          controllerLeePayloadReset();
+          return;
+      }
+    }
+    // On CF2, thrust is mapped 65536 <==> 4 * 12 grams
+    const float max_thrust = 70.0f / 1000.0f * 9.81f; // N
+    control->thrustSI = setpoint->thrust / UINT16_MAX * max_thrust;
+
+    qr = mkvec(
+      radians(setpoint->attitude.roll),
+      -radians(setpoint->attitude.pitch), // This is in the legacy coordinate system where pitch is inverted
+      desiredYaw);
+  }
+
+  // Attitude controller
+
+  // current rotation [R]
+  struct quat q = mkquat(state->attitudeQuaternion.x, state->attitudeQuaternion.y, state->attitudeQuaternion.z, state->attitudeQuaternion.w);
+  rpy = quat2rpy(q);
+  struct mat33 R = quat2rotmat(q);
+
+  // desired rotation [Rdes]
+  struct quat q_des = mat2quat(R_des);
+  rpy_des = quat2rpy(q_des);
+
+  // rotation error
+  struct mat33 eRM = msub(mmul(mtranspose(R_des), R), mmul(mtranspose(R), R_des));
+
+  struct vec eR = vscl(0.5f, mkvec(eRM.m[2][1], eRM.m[0][2], eRM.m[1][0]));
+
+  // angular velocity
+  omega = mkvec(
+    radians(sensors->gyro.x),
+    radians(sensors->gyro.y),
+    radians(sensors->gyro.z));
+
+  // Compute desired omega
+  struct vec xdes = mcolumn(R_des, 0);
+  struct vec ydes = mcolumn(R_des, 1);
+  struct vec zdes = mcolumn(R_des, 2);
+  struct vec hw = vzero();
+  // Desired Jerk and snap for now are zeros vector
+  struct vec desJerk = mkvec(setpoint->jerk.x, setpoint->jerk.y, setpoint->jerk.z);
+
+  if (control->thrustSI != 0) {
+    struct vec tmp = vsub(desJerk, vscl(vdot(zdes, desJerk), zdes));
+    hw = vscl(g_vehicleMass/control->thrustSI, tmp);
+  }
+
+  struct vec omega_des = mkvec(-vdot(hw,ydes), vdot(hw,xdes), 0);
+  
+  omega_r = mvmul(mmul(mtranspose(R), R_des), omega_des);
+
+  struct vec omega_error = vsub(omega, omega_r);
+  
+
+
+  // compute moments
+  // M = -kR eR - kw ew + w x Jw - J(w x wr)
+  u = vadd3(
+    vneg(veltmul(KR, eR)),
+    vneg(veltmul(Komega, omega_error)),
+    vcross(omega, veltmul(J, omega)));
+
+  // if (enableNN > 1) {
+  //   u = vsub(u, tau_a);
+  // }
+
+  control->controlMode = controlModeForceTorque;
+  control->torque[0] = u.x;
+  control->torque[1] = u.y;
+  control->torque[2] = u.z;
+
+  // ticks = usecTimestamp() - startTime;
+}
+
+PARAM_GROUP_START(ctrlLeeP)
+PARAM_ADD(PARAM_FLOAT, KR_x, &KR.x)
+PARAM_ADD(PARAM_FLOAT, KR_y, &KR.y)
+PARAM_ADD(PARAM_FLOAT, KR_z, &KR.z)
+// Attitude D
+PARAM_ADD(PARAM_FLOAT, Kw_x, &Komega.x)
+PARAM_ADD(PARAM_FLOAT, Kw_y, &Komega.y)
+PARAM_ADD(PARAM_FLOAT, Kw_z, &Komega.z)
+
+// J
+PARAM_ADD(PARAM_FLOAT, J_x, &J.x)
+PARAM_ADD(PARAM_FLOAT, J_y, &J.y)
+PARAM_ADD(PARAM_FLOAT, J_z, &J.z)
+
+// Position P
+PARAM_ADD(PARAM_FLOAT, Kpos_Px, &Kpos_P.x)
+PARAM_ADD(PARAM_FLOAT, Kpos_Py, &Kpos_P.y)
+PARAM_ADD(PARAM_FLOAT, Kpos_Pz, &Kpos_P.z)
+PARAM_ADD(PARAM_FLOAT, Kpos_P_limit, &Kpos_P_limit)
+// Position D
+PARAM_ADD(PARAM_FLOAT, Kpos_Dx, &Kpos_D.x)
+PARAM_ADD(PARAM_FLOAT, Kpos_Dy, &Kpos_D.y)
+PARAM_ADD(PARAM_FLOAT, Kpos_Dz, &Kpos_D.z)
+PARAM_ADD(PARAM_FLOAT, Kpos_D_limit, &Kpos_D_limit)
+// Position I
+PARAM_ADD(PARAM_FLOAT, Kpos_Ix, &Kpos_I.x)
+PARAM_ADD(PARAM_FLOAT, Kpos_Iy, &Kpos_I.y)
+PARAM_ADD(PARAM_FLOAT, Kpos_Iz, &Kpos_I.z)
+PARAM_ADD(PARAM_FLOAT, Kpos_I_limit, &Kpos_I_limit)
+
+PARAM_ADD(PARAM_FLOAT, mass, &g_vehicleMass)
+PARAM_GROUP_STOP(ctrlLeeP)
+
+
+LOG_GROUP_START(ctrlLeeP)
+
+LOG_ADD(LOG_FLOAT, KR_x, &KR.x)
+LOG_ADD(LOG_FLOAT, KR_y, &KR.y)
+LOG_ADD(LOG_FLOAT, KR_z, &KR.z)
+LOG_ADD(LOG_FLOAT, Kw_x, &Komega.x)
+LOG_ADD(LOG_FLOAT, Kw_y, &Komega.y)
+LOG_ADD(LOG_FLOAT, Kw_z, &Komega.z)
+
+LOG_ADD(LOG_FLOAT,Kpos_Px, &Kpos_P.x)
+LOG_ADD(LOG_FLOAT,Kpos_Py, &Kpos_P.y)
+LOG_ADD(LOG_FLOAT,Kpos_Pz, &Kpos_P.z)
+LOG_ADD(LOG_FLOAT,Kpos_Dx, &Kpos_D.x)
+LOG_ADD(LOG_FLOAT,Kpos_Dy, &Kpos_D.y)
+LOG_ADD(LOG_FLOAT,Kpos_Dz, &Kpos_D.z)
+
+
+LOG_ADD(LOG_FLOAT, thrustSI, &thrustSI)
+LOG_ADD(LOG_FLOAT, torquex, &u.x)
+LOG_ADD(LOG_FLOAT, torquey, &u.y)
+LOG_ADD(LOG_FLOAT, torquez, &u.z)
+
+// current angles
+LOG_ADD(LOG_FLOAT, rpyx, &rpy.x)
+LOG_ADD(LOG_FLOAT, rpyy, &rpy.y)
+LOG_ADD(LOG_FLOAT, rpyz, &rpy.z)
+
+// desired angles
+LOG_ADD(LOG_FLOAT, rpydx, &rpy_des.x)
+LOG_ADD(LOG_FLOAT, rpydy, &rpy_des.y)
+LOG_ADD(LOG_FLOAT, rpydz, &rpy_des.z)
+
+// errors
+LOG_ADD(LOG_FLOAT, error_posx, &p_error.x)
+LOG_ADD(LOG_FLOAT, error_posy, &p_error.y)
+LOG_ADD(LOG_FLOAT, error_posz, &p_error.z)
+
+LOG_ADD(LOG_FLOAT, error_velx, &v_error.x)
+LOG_ADD(LOG_FLOAT, error_vely, &v_error.y)
+LOG_ADD(LOG_FLOAT, error_velz, &v_error.z)
+
+// omega
+LOG_ADD(LOG_FLOAT, omegax, &omega.x)
+LOG_ADD(LOG_FLOAT, omegay, &omega.y)
+LOG_ADD(LOG_FLOAT, omegaz, &omega.z)
+
+// omega_r
+LOG_ADD(LOG_FLOAT, omegarx, &omega_r.x)
+LOG_ADD(LOG_FLOAT, omegary, &omega_r.y)
+LOG_ADD(LOG_FLOAT, omegarz, &omega_r.z)
+
+// LOG_ADD(LOG_UINT32, ticks, &ticks)
+
+LOG_GROUP_STOP(ctrlLeeP)

--- a/src/modules/src/controller_lee_payload.c
+++ b/src/modules/src/controller_lee_payload.c
@@ -347,7 +347,20 @@ PARAM_ADD(PARAM_FLOAT, Kpos_Iy, &Kpos_I.y)
 PARAM_ADD(PARAM_FLOAT, Kpos_Iz, &Kpos_I.z)
 PARAM_ADD(PARAM_FLOAT, Kpos_I_limit, &Kpos_I_limit)
 
+// Cable P
+PARAM_ADD(PARAM_FLOAT, Kqx, &K_q.x)
+PARAM_ADD(PARAM_FLOAT, Kqy, &K_q.y)
+PARAM_ADD(PARAM_FLOAT, Kqz, &K_q.z)
+
+// Cable P
+PARAM_ADD(PARAM_FLOAT, Kwx, &K_w.x)
+PARAM_ADD(PARAM_FLOAT, Kwy, &K_w.y)
+PARAM_ADD(PARAM_FLOAT, Kwz, &K_w.z)
+
 PARAM_ADD(PARAM_FLOAT, mass, &g_vehicleMass)
+PARAM_ADD(PARAM_FLOAT, massP, &mp)
+PARAM_ADD(PARAM_FLOAT, length, &l)
+
 PARAM_GROUP_STOP(ctrlLeeP)
 
 
@@ -382,15 +395,6 @@ LOG_ADD(LOG_FLOAT, rpyz, &rpy.z)
 LOG_ADD(LOG_FLOAT, rpydx, &rpy_des.x)
 LOG_ADD(LOG_FLOAT, rpydy, &rpy_des.y)
 LOG_ADD(LOG_FLOAT, rpydz, &rpy_des.z)
-
-// errors
-// LOG_ADD(LOG_FLOAT, error_posx, &p_error.x)
-// LOG_ADD(LOG_FLOAT, error_posy, &p_error.y)
-// LOG_ADD(LOG_FLOAT, error_posz, &p_error.z)
-
-// LOG_ADD(LOG_FLOAT, error_velx, &v_error.x)
-// LOG_ADD(LOG_FLOAT, error_vely, &v_error.y)
-// LOG_ADD(LOG_FLOAT, error_velz, &v_error.z)
 
 // omega
 LOG_ADD(LOG_FLOAT, omegax, &omega.x)

--- a/src/modules/src/planner.c
+++ b/src/modules/src/planner.c
@@ -45,9 +45,14 @@ static void plan_takeoff_or_landing(struct planner *p, struct vec curr_pos, floa
 	struct vec hover_pos = curr_pos;
 	hover_pos.z = hover_height;
 
+	// compute the shortest possible rotation towards 0
+	hover_yaw = normalize_radians(hover_yaw);
+	curr_yaw = normalize_radians(curr_yaw);
+	float goal_yaw = hover_yaw + shortest_signed_angle_radians(curr_yaw, hover_yaw);
+
 	piecewise_plan_7th_order_no_jerk(&p->planned_trajectory, duration,
 		curr_pos,  curr_yaw,  vzero(), 0, vzero(),
-		hover_pos, hover_yaw, vzero(), 0, vzero());
+		hover_pos, goal_yaw, vzero(), 0, vzero());
 }
 
 // ----------------- //
@@ -179,12 +184,13 @@ int plan_go_to_from(struct planner *p, const struct traj_eval *curr_eval, bool r
 	}
 
 	// compute the shortest possible rotation towards 0
+	float curr_yaw = normalize_radians(curr_eval->yaw);
 	hover_yaw = normalize_radians(hover_yaw);
-	float goal_yaw = hover_yaw + shortest_signed_angle_radians(hover_yaw, 0);
+	float goal_yaw = hover_yaw + shortest_signed_angle_radians(curr_yaw, hover_yaw);
 
 	piecewise_plan_7th_order_no_jerk(&p->planned_trajectory, duration,
-		curr_eval->pos, curr_eval->yaw, curr_eval->vel, curr_eval->omega.z, curr_eval->acc,
-		hover_pos,      hover_yaw,      vzero(),        goal_yaw,                  vzero());
+		curr_eval->pos, curr_yaw, curr_eval->vel, curr_eval->omega.z, curr_eval->acc,
+		hover_pos,      goal_yaw,      vzero(),        0,                  vzero());
 
 	p->reversed = false;
 	p->state = TRAJECTORY_STATE_FLYING;

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -128,7 +128,7 @@ static struct {
 } setpointCompressed;
 
 // for payloads
-static float payload_alpha = 0.1; // between 0...1; 1: no filter
+static float payload_alpha = 0.9; // between 0...1; 1: no filter
 static point_t payload_pos_last;         // m   (world frame)
 static velocity_t payload_vel_last;      // m/s (world frame)
 
@@ -326,7 +326,7 @@ static void stabilizerTask(void* param)
           payload_pos_last = state.payload_pos;
           payload_vel_last = state.payload_vel;
         } else {
-          state.payload_pos = payload_vel_last;
+          state.payload_pos = payload_pos_last;
           state.payload_vel = payload_vel_last;
         }
       }

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -128,8 +128,9 @@ static struct {
 } setpointCompressed;
 
 // for payloads
-point_t payload_last_pos;
-float payload_alpha = 0.9; // between 0...1; 1: no filter
+static float payload_alpha = 0.1; // between 0...1; 1: no filter
+static point_t payload_pos_last;         // m   (world frame)
+static velocity_t payload_vel_last;      // m/s (world frame)
 
 STATIC_MEM_TASK_ALLOC(stabilizerTask, STABILIZER_TASK_STACKSIZE);
 
@@ -262,7 +263,8 @@ static void stabilizerTask(void* param)
 
   rateSupervisorInit(&rateSupervisorContext, xTaskGetTickCount(), M2T(1000), 997, 1003, 1);
 
-  DEBUG_PRINT("Ready to fly.\n");
+  payload_pos_last.timestamp = 0;
+   DEBUG_PRINT("Ready to fly.\n");
 
   while(1) {
     // The sensor should unlock at 1kHz
@@ -291,36 +293,43 @@ static void stabilizerTask(void* param)
       // add the payload state here
       peerLocalizationOtherPosition_t* payloadPos = peerLocalizationGetPositionByID(255);
       if (payloadPos != NULL) {
-
+        
         // if we got a new state
-        if (payload_last_pos.timestamp < state.payload_pos.timestamp) {
+        if (payload_pos_last.timestamp < payloadPos->pos.timestamp) {
+          struct vec vel_filtered = vzero();
+          // in the beginning, estimate the velocity to be zero, otherwise use
+          // numeric estimation with filter
+          if (payload_pos_last.timestamp != 0) {
+            // estimate the velocity numerically
+            const float dt = (payloadPos->pos.timestamp - payload_pos_last.timestamp) / 1000.0f; //s
+            struct vec pos = mkvec(payloadPos->pos.x, payloadPos->pos.y, payloadPos->pos.z);
+            struct vec last_pos = mkvec(payload_pos_last.x, payload_pos_last.y, payload_pos_last.z);
+            struct vec vel = vdiv(vsub(pos, last_pos), dt);
+
+            // apply a simple complementary filter
+            struct vec vel_old = mkvec(payload_vel_last.x, payload_vel_last.y, payload_vel_last.z);
+            vel_filtered = vadd(vscl(1.0f - payload_alpha, vel_old), vscl(payload_alpha, vel));
+          }
           // update the position
           state.payload_pos.x = payloadPos->pos.x;
           state.payload_pos.y = payloadPos->pos.y;
           state.payload_pos.z = payloadPos->pos.z;
+          state.payload_pos.timestamp = payloadPos->pos.timestamp;
 
-          // estimate the velocity numerically
-          const float dt = (state.payload_pos.timestamp - payload_last_pos.timestamp) / 1000.0f; //s
-          struct vec pos = mkvec(state.payload_pos.x, state.payload_pos.y, state.payload_pos.z);
-          struct vec last_pos = mkvec(payload_last_pos.x, payload_last_pos.y, payload_last_pos.z);
-          struct vec vel = vdiv(vsub(pos, last_pos), dt);
-
-          // apply a simple complementary filter
-          struct vec vel_old = mkvec(state.payload_vel.x, state.payload_vel.y, state.payload_vel.z);
-          struct vec vel_filtered = vadd(vscl(1 - payload_alpha, vel_old), vscl(payload_alpha, vel));
-
+          // update the velocity
           state.payload_vel.x = vel_filtered.x;
           state.payload_vel.y = vel_filtered.y;
           state.payload_vel.z = vel_filtered.z;
-
-          payload_last_pos = state.payload_pos;
+          state.payload_vel.timestamp = payloadPos->pos.timestamp;
+          
+          // update state
+          payload_pos_last = state.payload_pos;
+          payload_vel_last = state.payload_vel;
+        } else {
+          state.payload_pos = payload_vel_last;
+          state.payload_vel = payload_vel_last;
         }
-      } else {
-        state.payload_pos.x = NAN;
-        state.payload_pos.y = NAN;
-        state.payload_pos.z = NAN;
       }
-
       compressState();
 
       if (crtpCommanderHighLevelGetSetpoint(&tempSetpoint, &state, tick)) {
@@ -418,6 +427,10 @@ PARAM_ADD_CORE(PARAM_UINT8, controller, &controllerType)
  * @brief If set to nonzero will turn off power
  */
 PARAM_ADD_CORE(PARAM_UINT8, stop, &emergencyStop)
+
+
+PARAM_ADD_CORE(PARAM_FLOAT, pAlpha, &payload_alpha)
+
 PARAM_GROUP_STOP(stabilizer)
 
 
@@ -865,32 +878,32 @@ LOG_ADD(LOG_INT16, rateYaw, &stateCompressed.rateYaw)
 /**
  * @brief The position of the payload in the global reference frame, X [mm]
  */
-LOG_ADD(LOG_INT16, x, &stateCompressed.px)
+LOG_ADD(LOG_INT16, px, &stateCompressed.px)
 
 /**
  * @brief The position of the payload in the global reference frame, Y [mm]
  */
-LOG_ADD(LOG_INT16, y, &stateCompressed.py)
+LOG_ADD(LOG_INT16, py, &stateCompressed.py)
 
 /**
  * @brief The position of the payload in the global reference frame, Z [mm]
  */
-LOG_ADD(LOG_INT16, z, &stateCompressed.pz)
+LOG_ADD(LOG_INT16, pz, &stateCompressed.pz)
 
 /**
  * @brief The velocity of the payload in the global reference frame, X [mm/s]
  */
-LOG_ADD(LOG_INT16, vx, &stateCompressed.pvx)
+LOG_ADD(LOG_INT16, pvx, &stateCompressed.pvx)
 
 /**
  * @brief The velocity of the payload in the global reference frame, Y [mm/s]
  */
-LOG_ADD(LOG_INT16, vy, &stateCompressed.pvy)
+LOG_ADD(LOG_INT16, pvy, &stateCompressed.pvy)
 
 /**
  * @brief The velocity of the payload in the global reference frame, Z [mm/s]
  */
-LOG_ADD(LOG_INT16, vz, &stateCompressed.pvz)
+LOG_ADD(LOG_INT16, pvz, &stateCompressed.pvz)
 
 
 LOG_GROUP_STOP(stateEstimateZ)

--- a/test_python/test_controller_lee_payload.py
+++ b/test_python/test_controller_lee_payload.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import cffirmware
+
+def test_controller_lee_payload():
+
+    cffirmware.controllerLeePayloadInit()
+
+    control = cffirmware.control_t()
+    setpoint = cffirmware.setpoint_t()
+    setpoint.mode.z = cffirmware.modeAbs
+    setpoint.position.z = 0
+    setpoint.mode.x = cffirmware.modeVelocity
+    setpoint.velocity.x = 0
+    setpoint.mode.y = cffirmware.modeVelocity
+    setpoint.velocity.y = 0
+    setpoint.mode.yaw = cffirmware.modeVelocity
+    setpoint.attitudeRate.yaw = 0
+
+    state = cffirmware.state_t()
+    state.attitude.roll = 0
+    state.attitude.pitch = -0 # WARNING: This needs to be negated
+    state.attitude.yaw = 0
+    state.position.x = 0
+    state.position.y = 0
+    state.position.z = 0
+    state.velocity.x = 0
+    state.velocity.y = 0
+    state.velocity.z = 0
+
+    sensors = cffirmware.sensorData_t()
+    sensors.gyro.x = 0
+    sensors.gyro.y = 0
+    sensors.gyro.z = 0
+
+    tick = 100
+
+    cffirmware.controllerLeePayload(control, setpoint,sensors,state,tick)
+    # control.thrust will be at a (tuned) hover-state
+    assert control.controlMode == cffirmware.controlModeForceTorque
+    assert control.torque[0] == 0
+    assert control.torque[1] == 0
+    assert control.torque[2] == 0


### PR DESCRIPTION
This adds:

* LeePayload controller with Python bindings (currently: just a copy of the existing Lee controller)
* payload_pos and payload_vel as part of the state vector
* Logic to populate payload_{pos,vel} by using the peer localization system, i.e., the payload needs to be tracked on the host like another Crazyflie (with id 255).
* Logic to log payload_{pos,vel}