### PR TITLE
refactor controllerLee to use a state/param struct

### DIFF
--- a/src/modules/interface/controller_lee.h
+++ b/src/modules/interface/controller_lee.h
@@ -27,11 +27,53 @@
 
 #include "stabilizer_types.h"
 
-void controllerLeeInit(void);
-bool controllerLeeTest(void);
-void controllerLee(control_t *control, setpoint_t *setpoint,
+// This structure contains the mutable state and inmutable parameters
+typedef struct controllerLee_s {
+    float mass; // TODO: should be CF global for other modules
+    float thrustSI;
+    struct vec J; // Inertia matrix (diagonal matrix); kg m^2
+
+    // Position PID
+    struct vec Kpos_P; // Kp in paper
+    float Kpos_P_limit;
+    struct vec Kpos_D; // Kv in paper
+    float Kpos_D_limit;
+    struct vec Kpos_I; // not in paper
+    float Kpos_I_limit;
+    struct vec i_error_pos;
+    struct vec p_error;
+    struct vec v_error;
+    // Attitude PID
+    struct vec KR;
+    struct vec Komega;
+    struct vec KI;
+    struct vec i_error_att;
+    // Logging variables
+    struct vec rpy;
+    struct vec rpy_des;
+    struct vec qr;
+    struct mat33 R_des;
+    struct vec omega;
+    struct vec omega_r;
+    struct vec u;
+} controllerLee_t;
+
+
+
+void controllerLeeInit(controllerLee_t* self);
+void controllerLeeReset(controllerLee_t* self);
+void controllerLee(controllerLee_t* self, control_t *control, setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick);
+
+#ifdef CRAZYFLIE_FW
+void controllerLeeFirmwareInit(void);
+bool controllerLeeFirmwareTest(void);
+void controllerLeeFirmware(control_t *control, setpoint_t *setpoint,
+                                         const sensorData_t *sensors,
+                                         const state_t *state,
+                                         const uint32_t tick);
+#endif // CRAZYFLIE_FW defined
 
 #endif //__CONTROLLER_LEE_H__

--- a/src/modules/src/controller.c
+++ b/src/modules/src/controller.c
@@ -32,7 +32,7 @@ static ControllerFcns controllerFunctions[] = {
   {.init = controllerINDIInit, .test = controllerINDITest, .update = controllerINDI, .name = "INDI"},
   {.init = controllerSJCInit, .test = controllerSJCTest, .update = controllerSJC, .name = "SJC"},
   {.init = controllerMellingerSIInit, .test = controllerMellingerSITest, .update = controllerMellingerSI, .name = "MellingerSI"},
-  {.init = controllerLeeInit, .test = controllerLeeTest, .update = controllerLee, .name = "Lee"},
+  {.init = controllerLeeFirmwareInit, .test = controllerLeeFirmwareTest, .update = controllerLeeFirmware, .name = "Lee"},
   {.init = controllerLeePayloadInit, .test = controllerLeePayloadTest, .update = controllerLeePayload, .name = "LeePayload"},
 };
 

--- a/src/modules/src/controller_lee.c
+++ b/src/modules/src/controller_lee.c
@@ -39,47 +39,35 @@ TODO:
 */
 
 #include <math.h>
+#include <string.h>
 
-#include "param.h"
-#include "log.h"
 #include "math3d.h"
 #include "controller_lee.h"
 
 #define GRAVITY_MAGNITUDE (9.81f)
 
-static float g_vehicleMass = 0.034; // TODO: should be CF global for other modules
-static float thrustSI;
-// Inertia matrix (diagonal matrix), see
-// System Identification of the Crazyflie 2.0 Nano Quadrocopter
-// BA theses, Julian Foerster, ETHZ
-// https://polybox.ethz.ch/index.php/s/20dde63ee00ffe7085964393a55a91c7
-static struct vec J = {16.571710e-6, 16.655602e-6, 29.261652e-6}; // kg m^2
+static controllerLee_t g_self = {
+  .mass = 0.034, // TODO: should be CF global for other modules
 
-// Position PID
-static struct vec Kpos_P = {9, 9, 9}; // Kp in paper
-static float Kpos_P_limit = 100;
-static struct vec Kpos_D = {7, 7, 7}; // Kv in paper
-static float Kpos_D_limit = 100;
-static struct vec Kpos_I = {5, 5, 5}; // not in paper
-static float Kpos_I_limit = 2;
-static struct vec i_error_pos;
-static struct vec p_error;
-static struct vec v_error;
-// Attitude PID
-static struct vec KR = {0.0055, 0.0055, 0.01};
-static struct vec Komega = {0.0013, 0.0013, 0.002};
-static struct vec KI = {0.012, 0.018, 0.015};
-static struct vec i_error_att;
-// Logging variables
-static struct vec rpy;
-static struct vec rpy_des;
-static struct vec qr;
-static struct mat33 R_des;
-static struct vec omega;
-static struct vec omega_r;
-static struct vec u;
+  // Inertia matrix (diagonal matrix), see
+  // System Identification of the Crazyflie 2.0 Nano Quadrocopter
+  // BA theses, Julian Foerster, ETHZ
+  // https://polybox.ethz.ch/index.php/s/20dde63ee00ffe7085964393a55a91c7
+  .J = {16.571710e-6, 16.655602e-6, 29.261652e-6}, // kg m^2
 
-// static uint32_t ticks;
+  // Position PID
+  .Kpos_P = {9, 9, 9}, // Kp in paper
+  .Kpos_P_limit = 100,
+  .Kpos_D = {7, 7, 7}, // Kv in paper
+  .Kpos_D_limit = 100,
+  .Kpos_I = {5, 5, 5}, // not in paper
+  .Kpos_I_limit = 2,
+
+  // Attitude PID
+  .KR = {0.0055, 0.0055, 0.01},
+  .Komega = {0.0013, 0.0013, 0.002},
+  .KI = {0.012, 0.018, 0.015},
+};
 
 static inline struct vec vclampscl(struct vec value, float min, float max) {
   return mkvec(
@@ -88,23 +76,26 @@ static inline struct vec vclampscl(struct vec value, float min, float max) {
     clamp(value.z, min, max));
 }
 
-void controllerLeeReset(void)
+void controllerLeeReset(controllerLee_t* self)
 {
-  i_error_pos = vzero();
-  i_error_att = vzero();
+  self->i_error_pos = vzero();
+  self->i_error_att = vzero();
 }
 
-void controllerLeeInit(void)
+void controllerLeeInit(controllerLee_t* self)
 {
-  controllerLeeReset();
+  // copy default values (bindings), or NOP (firmware)
+  *self = g_self;
+
+  controllerLeeReset(self);
 }
 
-bool controllerLeeTest(void)
+bool controllerLeeTest(controllerLee_t* self)
 {
   return true;
 }
 
-void controllerLee(control_t *control, setpoint_t *setpoint,
+void controllerLee(controllerLee_t* self, control_t *control, setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick)
@@ -128,8 +119,8 @@ void controllerLee(control_t *control, setpoint_t *setpoint,
     desiredYaw = radians(setpoint->attitude.yaw);
   } else if (setpoint->mode.quat == modeAbs) {
     struct quat setpoint_quat = mkquat(setpoint->attitudeQuaternion.x, setpoint->attitudeQuaternion.y, setpoint->attitudeQuaternion.z, setpoint->attitudeQuaternion.w);
-    rpy_des = quat2rpy(setpoint_quat);
-    desiredYaw = rpy_des.z;
+    self->rpy_des = quat2rpy(setpoint_quat);
+    desiredYaw = self->rpy_des.z;
   }
 
   // Position controller
@@ -143,27 +134,27 @@ void controllerLee(control_t *control, setpoint_t *setpoint,
     struct vec stateVel = mkvec(state->velocity.x, state->velocity.y, state->velocity.z);
 
     // errors
-    struct vec pos_e = vclampscl(vsub(pos_d, statePos), -Kpos_P_limit, Kpos_P_limit);
-    struct vec vel_e = vclampscl(vsub(vel_d, stateVel), -Kpos_D_limit, Kpos_D_limit);
-    i_error_pos = vadd(i_error_pos, vscl(dt, pos_e));
-    p_error = pos_e;
-    v_error = vel_e;
+    struct vec pos_e = vclampscl(vsub(pos_d, statePos), -self->Kpos_P_limit, self->Kpos_P_limit);
+    struct vec vel_e = vclampscl(vsub(vel_d, stateVel), -self->Kpos_D_limit, self->Kpos_D_limit);
+    self->i_error_pos = vadd(self->i_error_pos, vscl(dt, pos_e));
+    self->p_error = pos_e;
+    self->v_error = vel_e;
 
     struct vec F_d = vadd4(
       acc_d,
-      veltmul(Kpos_D, vel_e),
-      veltmul(Kpos_P, pos_e),
-      veltmul(Kpos_I, i_error_pos));
+      veltmul(self->Kpos_D, vel_e),
+      veltmul(self->Kpos_P, pos_e),
+      veltmul(self->Kpos_I, self->i_error_pos));
     
    
     struct quat q = mkquat(state->attitudeQuaternion.x, state->attitudeQuaternion.y, state->attitudeQuaternion.z, state->attitudeQuaternion.w);
     struct mat33 R = quat2rotmat(q);
     struct vec z  = vbasis(2);
-    control->thrustSI = g_vehicleMass*vdot(F_d , mvmul(R, z));
-    thrustSI = control->thrustSI;
+    control->thrustSI = self->mass*vdot(F_d , mvmul(R, z));
+    self->thrustSI = control->thrustSI;
     // Reset the accumulated error while on the ground
     if (control->thrustSI < 0.01f) {
-      controllerLeeReset();
+      controllerLeeReset(self);
     }
 
   // Compute Desired Rotation matrix
@@ -185,7 +176,7 @@ void controllerLee(control_t *control, setpoint_t *setpoint,
     } 
     xdes = vcross(ydes, zdes);
     
-    R_des = mcolumns(xdes, ydes, zdes);
+    self->R_des = mcolumns(xdes, ydes, zdes);
 
   } else {
     if (setpoint->mode.z == modeDisable) {
@@ -195,7 +186,7 @@ void controllerLee(control_t *control, setpoint_t *setpoint,
           control->torque[0] = 0;
           control->torque[1] = 0;
           control->torque[2] = 0;
-          controllerLeeReset();
+          controllerLeeReset(self);
           return;
       }
     }
@@ -203,7 +194,7 @@ void controllerLee(control_t *control, setpoint_t *setpoint,
     const float max_thrust = 70.0f / 1000.0f * 9.81f; // N
     control->thrustSI = setpoint->thrust / UINT16_MAX * max_thrust;
 
-    qr = mkvec(
+   self->qr = mkvec(
       radians(setpoint->attitude.roll),
       -radians(setpoint->attitude.pitch), // This is in the legacy coordinate system where pitch is inverted
       desiredYaw);
@@ -213,157 +204,182 @@ void controllerLee(control_t *control, setpoint_t *setpoint,
 
   // current rotation [R]
   struct quat q = mkquat(state->attitudeQuaternion.x, state->attitudeQuaternion.y, state->attitudeQuaternion.z, state->attitudeQuaternion.w);
-  rpy = quat2rpy(q);
+  self->rpy = quat2rpy(q);
   struct mat33 R = quat2rotmat(q);
 
   // desired rotation [Rdes]
-  struct quat q_des = mat2quat(R_des);
-  rpy_des = quat2rpy(q_des);
+  struct quat q_des = mat2quat(self->R_des);
+  self->rpy_des = quat2rpy(q_des);
 
   // rotation error
-  struct mat33 eRM = msub(mmul(mtranspose(R_des), R), mmul(mtranspose(R), R_des));
+  struct mat33 eRM = msub(mmul(mtranspose(self->R_des), R), mmul(mtranspose(R), self->R_des));
 
   struct vec eR = vscl(0.5f, mkvec(eRM.m[2][1], eRM.m[0][2], eRM.m[1][0]));
 
   // angular velocity
-  omega = mkvec(
+  self->omega = mkvec(
     radians(sensors->gyro.x),
     radians(sensors->gyro.y),
     radians(sensors->gyro.z));
 
   // Compute desired omega
-  struct vec xdes = mcolumn(R_des, 0);
-  struct vec ydes = mcolumn(R_des, 1);
-  struct vec zdes = mcolumn(R_des, 2);
+  struct vec xdes = mcolumn(self->R_des, 0);
+  struct vec ydes = mcolumn(self->R_des, 1);
+  struct vec zdes = mcolumn(self->R_des, 2);
   struct vec hw = vzero();
   // Desired Jerk and snap for now are zeros vector
   struct vec desJerk = mkvec(setpoint->jerk.x, setpoint->jerk.y, setpoint->jerk.z);
 
   if (control->thrustSI != 0) {
     struct vec tmp = vsub(desJerk, vscl(vdot(zdes, desJerk), zdes));
-    hw = vscl(g_vehicleMass/control->thrustSI, tmp);
+    hw = vscl(self->mass/control->thrustSI, tmp);
   }
   struct vec z_w = mkvec(0,0,1); 
   float desiredYawRate = radians(setpoint->attitudeRate.yaw) * vdot(zdes,z_w);
   struct vec omega_des = mkvec(-vdot(hw,ydes), vdot(hw,xdes), desiredYawRate);
   
-  omega_r = mvmul(mmul(mtranspose(R), R_des), omega_des);
+  self->omega_r = mvmul(mmul(mtranspose(R), self->R_des), omega_des);
 
-  struct vec omega_error = vsub(omega, omega_r);
+  struct vec omega_error = vsub(self->omega, self->omega_r);
   
   // Integral part on angle
-  i_error_att = vadd(i_error_att, vscl(dt, eR));
+  self->i_error_att = vadd(self->i_error_att, vscl(dt, eR));
 
 
   // compute moments
   // M = -kR eR - kw ew + w x Jw - J(w x wr)
-  u = vadd4(
-    vneg(veltmul(KR, eR)),
-    vneg(veltmul(Komega, omega_error)),
-    vneg(veltmul(KI, i_error_att)),
-    vcross(omega, veltmul(J, omega)));
+  self->u = vadd4(
+    vneg(veltmul(self->KR, eR)),
+    vneg(veltmul(self->Komega, omega_error)),
+    vneg(veltmul(self->KI, self->i_error_att)),
+    vcross(self->omega, veltmul(self->J, self->omega)));
 
   // if (enableNN > 1) {
   //   u = vsub(u, tau_a);
   // }
 
   control->controlMode = controlModeForceTorque;
-  control->torque[0] = u.x;
-  control->torque[1] = u.y;
-  control->torque[2] = u.z;
+  control->torque[0] = self->u.x;
+  control->torque[1] = self->u.y;
+  control->torque[2] = self->u.z;
 
   // ticks = usecTimestamp() - startTime;
 }
 
+#ifdef CRAZYFLIE_FW
+
+#include "param.h"
+#include "log.h"
+
+void controllerLeeFirmwareInit(void)
+{
+  controllerLeeInit(&g_self);
+}
+
+bool controllerLeeFirmwareTest(void)
+{
+  return true;
+}
+
+void controllerLeeFirmware(control_t *control, setpoint_t *setpoint,
+                                         const sensorData_t *sensors,
+                                         const state_t *state,
+                                         const uint32_t tick)
+{
+  controllerLee(&g_self, control, setpoint, sensors, state, tick);
+}
+
 PARAM_GROUP_START(ctrlLee)
-PARAM_ADD(PARAM_FLOAT, KR_x, &KR.x)
-PARAM_ADD(PARAM_FLOAT, KR_y, &KR.y)
-PARAM_ADD(PARAM_FLOAT, KR_z, &KR.z)
+PARAM_ADD(PARAM_FLOAT, KR_x, &g_self.KR.x)
+PARAM_ADD(PARAM_FLOAT, KR_y, &g_self.KR.y)
+PARAM_ADD(PARAM_FLOAT, KR_z, &g_self.KR.z)
 // Attitude I
-PARAM_ADD(PARAM_FLOAT, KI_x, &KI.x)
-PARAM_ADD(PARAM_FLOAT, KI_y, &KI.y)
-PARAM_ADD(PARAM_FLOAT, KI_z, &KI.z)
+PARAM_ADD(PARAM_FLOAT, KI_x, &g_self.KI.x)
+PARAM_ADD(PARAM_FLOAT, KI_y, &g_self.KI.y)
+PARAM_ADD(PARAM_FLOAT, KI_z, &g_self.KI.z)
 // Attitude D
-PARAM_ADD(PARAM_FLOAT, Kw_x, &Komega.x)
-PARAM_ADD(PARAM_FLOAT, Kw_y, &Komega.y)
-PARAM_ADD(PARAM_FLOAT, Kw_z, &Komega.z)
+PARAM_ADD(PARAM_FLOAT, Kw_x, &g_self.Komega.x)
+PARAM_ADD(PARAM_FLOAT, Kw_y, &g_self.Komega.y)
+PARAM_ADD(PARAM_FLOAT, Kw_z, &g_self.Komega.z)
 
 // J
-PARAM_ADD(PARAM_FLOAT, J_x, &J.x)
-PARAM_ADD(PARAM_FLOAT, J_y, &J.y)
-PARAM_ADD(PARAM_FLOAT, J_z, &J.z)
+PARAM_ADD(PARAM_FLOAT, J_x, &g_self.J.x)
+PARAM_ADD(PARAM_FLOAT, J_y, &g_self.J.y)
+PARAM_ADD(PARAM_FLOAT, J_z, &g_self.J.z)
 
 // Position P
-PARAM_ADD(PARAM_FLOAT, Kpos_Px, &Kpos_P.x)
-PARAM_ADD(PARAM_FLOAT, Kpos_Py, &Kpos_P.y)
-PARAM_ADD(PARAM_FLOAT, Kpos_Pz, &Kpos_P.z)
-PARAM_ADD(PARAM_FLOAT, Kpos_P_limit, &Kpos_P_limit)
+PARAM_ADD(PARAM_FLOAT, Kpos_Px, &g_self.Kpos_P.x)
+PARAM_ADD(PARAM_FLOAT, Kpos_Py, &g_self.Kpos_P.y)
+PARAM_ADD(PARAM_FLOAT, Kpos_Pz, &g_self.Kpos_P.z)
+PARAM_ADD(PARAM_FLOAT, Kpos_P_limit, &g_self.Kpos_P_limit)
 // Position D
-PARAM_ADD(PARAM_FLOAT, Kpos_Dx, &Kpos_D.x)
-PARAM_ADD(PARAM_FLOAT, Kpos_Dy, &Kpos_D.y)
-PARAM_ADD(PARAM_FLOAT, Kpos_Dz, &Kpos_D.z)
-PARAM_ADD(PARAM_FLOAT, Kpos_D_limit, &Kpos_D_limit)
+PARAM_ADD(PARAM_FLOAT, Kpos_Dx, &g_self.Kpos_D.x)
+PARAM_ADD(PARAM_FLOAT, Kpos_Dy, &g_self.Kpos_D.y)
+PARAM_ADD(PARAM_FLOAT, Kpos_Dz, &g_self.Kpos_D.z)
+PARAM_ADD(PARAM_FLOAT, Kpos_D_limit, &g_self.Kpos_D_limit)
 // Position I
-PARAM_ADD(PARAM_FLOAT, Kpos_Ix, &Kpos_I.x)
-PARAM_ADD(PARAM_FLOAT, Kpos_Iy, &Kpos_I.y)
-PARAM_ADD(PARAM_FLOAT, Kpos_Iz, &Kpos_I.z)
-PARAM_ADD(PARAM_FLOAT, Kpos_I_limit, &Kpos_I_limit)
+PARAM_ADD(PARAM_FLOAT, Kpos_Ix, &g_self.Kpos_I.x)
+PARAM_ADD(PARAM_FLOAT, Kpos_Iy, &g_self.Kpos_I.y)
+PARAM_ADD(PARAM_FLOAT, Kpos_Iz, &g_self.Kpos_I.z)
+PARAM_ADD(PARAM_FLOAT, Kpos_I_limit, &g_self.Kpos_I_limit)
 
-PARAM_ADD(PARAM_FLOAT, mass, &g_vehicleMass)
+PARAM_ADD(PARAM_FLOAT, mass, &g_self.mass)
 PARAM_GROUP_STOP(ctrlLee)
 
 
 LOG_GROUP_START(ctrlLee)
 
-LOG_ADD(LOG_FLOAT, KR_x, &KR.x)
-LOG_ADD(LOG_FLOAT, KR_y, &KR.y)
-LOG_ADD(LOG_FLOAT, KR_z, &KR.z)
-LOG_ADD(LOG_FLOAT, Kw_x, &Komega.x)
-LOG_ADD(LOG_FLOAT, Kw_y, &Komega.y)
-LOG_ADD(LOG_FLOAT, Kw_z, &Komega.z)
+LOG_ADD(LOG_FLOAT, KR_x, &g_self.KR.x)
+LOG_ADD(LOG_FLOAT, KR_y, &g_self.KR.y)
+LOG_ADD(LOG_FLOAT, KR_z, &g_self.KR.z)
+LOG_ADD(LOG_FLOAT, Kw_x, &g_self.Komega.x)
+LOG_ADD(LOG_FLOAT, Kw_y, &g_self.Komega.y)
+LOG_ADD(LOG_FLOAT, Kw_z, &g_self.Komega.z)
 
-LOG_ADD(LOG_FLOAT,Kpos_Px, &Kpos_P.x)
-LOG_ADD(LOG_FLOAT,Kpos_Py, &Kpos_P.y)
-LOG_ADD(LOG_FLOAT,Kpos_Pz, &Kpos_P.z)
-LOG_ADD(LOG_FLOAT,Kpos_Dx, &Kpos_D.x)
-LOG_ADD(LOG_FLOAT,Kpos_Dy, &Kpos_D.y)
-LOG_ADD(LOG_FLOAT,Kpos_Dz, &Kpos_D.z)
+LOG_ADD(LOG_FLOAT,Kpos_Px, &g_self.Kpos_P.x)
+LOG_ADD(LOG_FLOAT,Kpos_Py, &g_self.Kpos_P.y)
+LOG_ADD(LOG_FLOAT,Kpos_Pz, &g_self.Kpos_P.z)
+LOG_ADD(LOG_FLOAT,Kpos_Dx, &g_self.Kpos_D.x)
+LOG_ADD(LOG_FLOAT,Kpos_Dy, &g_self.Kpos_D.y)
+LOG_ADD(LOG_FLOAT,Kpos_Dz, &g_self.Kpos_D.z)
 
 
-LOG_ADD(LOG_FLOAT, thrustSI, &thrustSI)
-LOG_ADD(LOG_FLOAT, torquex, &u.x)
-LOG_ADD(LOG_FLOAT, torquey, &u.y)
-LOG_ADD(LOG_FLOAT, torquez, &u.z)
+LOG_ADD(LOG_FLOAT, thrustSI, &g_self.thrustSI)
+LOG_ADD(LOG_FLOAT, torquex, &g_self.u.x)
+LOG_ADD(LOG_FLOAT, torquey, &g_self.u.y)
+LOG_ADD(LOG_FLOAT, torquez, &g_self.u.z)
 
 // current angles
-LOG_ADD(LOG_FLOAT, rpyx, &rpy.x)
-LOG_ADD(LOG_FLOAT, rpyy, &rpy.y)
-LOG_ADD(LOG_FLOAT, rpyz, &rpy.z)
+LOG_ADD(LOG_FLOAT, rpyx, &g_self.rpy.x)
+LOG_ADD(LOG_FLOAT, rpyy, &g_self.rpy.y)
+LOG_ADD(LOG_FLOAT, rpyz, &g_self.rpy.z)
 
 // desired angles
-LOG_ADD(LOG_FLOAT, rpydx, &rpy_des.x)
-LOG_ADD(LOG_FLOAT, rpydy, &rpy_des.y)
-LOG_ADD(LOG_FLOAT, rpydz, &rpy_des.z)
+LOG_ADD(LOG_FLOAT, rpydx, &g_self.rpy_des.x)
+LOG_ADD(LOG_FLOAT, rpydy, &g_self.rpy_des.y)
+LOG_ADD(LOG_FLOAT, rpydz, &g_self.rpy_des.z)
 
 // errors
-LOG_ADD(LOG_FLOAT, error_posx, &p_error.x)
-LOG_ADD(LOG_FLOAT, error_posy, &p_error.y)
-LOG_ADD(LOG_FLOAT, error_posz, &p_error.z)
+LOG_ADD(LOG_FLOAT, error_posx, &g_self.p_error.x)
+LOG_ADD(LOG_FLOAT, error_posy, &g_self.p_error.y)
+LOG_ADD(LOG_FLOAT, error_posz, &g_self.p_error.z)
 
-LOG_ADD(LOG_FLOAT, error_velx, &v_error.x)
-LOG_ADD(LOG_FLOAT, error_vely, &v_error.y)
-LOG_ADD(LOG_FLOAT, error_velz, &v_error.z)
+LOG_ADD(LOG_FLOAT, error_velx, &g_self.v_error.x)
+LOG_ADD(LOG_FLOAT, error_vely, &g_self.v_error.y)
+LOG_ADD(LOG_FLOAT, error_velz, &g_self.v_error.z)
 
 // omega
-LOG_ADD(LOG_FLOAT, omegax, &omega.x)
-LOG_ADD(LOG_FLOAT, omegay, &omega.y)
-LOG_ADD(LOG_FLOAT, omegaz, &omega.z)
+LOG_ADD(LOG_FLOAT, omegax, &g_self.omega.x)
+LOG_ADD(LOG_FLOAT, omegay, &g_self.omega.y)
+LOG_ADD(LOG_FLOAT, omegaz, &g_self.omega.z)
 
 // omega_r
-LOG_ADD(LOG_FLOAT, omegarx, &omega_r.x)
-LOG_ADD(LOG_FLOAT, omegary, &omega_r.y)
-LOG_ADD(LOG_FLOAT, omegarz, &omega_r.z)
+LOG_ADD(LOG_FLOAT, omegarx, &g_self.omega_r.x)
+LOG_ADD(LOG_FLOAT, omegary, &g_self.omega_r.y)
+LOG_ADD(LOG_FLOAT, omegarz, &g_self.omega_r.z)
 
 // LOG_ADD(LOG_UINT32, ticks, &ticks)
 
 LOG_GROUP_STOP(ctrlLee)
+
+#endif // CRAZYFLIE_FW defined

--- a/test_python/test_controller_lee.py
+++ b/test_python/test_controller_lee.py
@@ -4,7 +4,11 @@ import cffirmware
 
 def test_controller_lee():
 
-    cffirmware.controllerLeeInit()
+    lee = cffirmware.controllerLee_t()
+
+    cffirmware.controllerLeeInit(lee)
+    # now we can change some controller parameters
+    lee.Kpos_D.z = 5
 
     control = cffirmware.control_t()
     setpoint = cffirmware.setpoint_t()
@@ -35,7 +39,7 @@ def test_controller_lee():
 
     tick = 100
 
-    cffirmware.controllerLee(control, setpoint,sensors,state,tick)
+    cffirmware.controllerLee(lee,control,setpoint,sensors,state,tick)
     # control.thrust will be at a (tuned) hover-state
     assert control.controlMode == cffirmware.controlModeForceTorque
     assert control.torque[0] == 0


### PR DESCRIPTION
* This enables tuning of parameters and logging/plotting of internal
  states from a Python script

I didn't flight test this, but I did consider the case that we switch controllers mid-flight for testing. You can do a similar change for the payload controller or let me do it once the test failure is fixed. I think this failure is something we want to fix regardless, since it seems to be some singularity that could cause a fatal crash mid-flight.